### PR TITLE
Config current key info added

### DIFF
--- a/src/main/java/imconfig/Config.java
+++ b/src/main/java/imconfig/Config.java
@@ -58,6 +58,8 @@ public interface Config {
     /** @return <code>true</code> if there is a multi-valued property with the given key */
     boolean hasMultivaluedProperty(String key);
 
+    /** @return the current key */
+    String key();
 
     /** @return An iterable object over all the keys of the configuration,
      *  even for those which have no value */

--- a/src/main/java/imconfig/internal/EmptyConfig.java
+++ b/src/main/java/imconfig/internal/EmptyConfig.java
@@ -51,6 +51,10 @@ public class EmptyConfig implements Config {
         return false;
     }
 
+    @Override
+    public String key() {
+        return null;
+    }
 
     @Override
     public Iterable<String> keys() {

--- a/src/main/java/imconfig/internal/MapBasedConfig.java
+++ b/src/main/java/imconfig/internal/MapBasedConfig.java
@@ -8,15 +8,26 @@ import java.util.stream.*;
 @SuppressWarnings("unchecked")
 public class MapBasedConfig extends AbstractConfig {
 
+    private final String key;
     private final Map<String,?> values;
 
     MapBasedConfig(
         ConfigFactory builder,
         Map<String,?> values,
-        Map<String,PropertyDefinition> definitions
+        Map<String,PropertyDefinition> definitions,
+        String key
     ) {
         super(builder, definitions);
         this.values = Map.copyOf(values);
+        this.key = key;
+    }
+
+    MapBasedConfig(
+            ConfigFactory builder,
+            Map<String,?> values,
+            Map<String,PropertyDefinition> definitions
+    ) {
+        this(builder,values, definitions, "");
     }
 
     MapBasedConfig(
@@ -57,9 +68,10 @@ public class MapBasedConfig extends AbstractConfig {
 
     @Override
     public Config inner(String keyPrefix) {
-        return this
-            .filtered(it -> it.startsWith(keyPrefix+"."))
-            .alteringKeys(it -> it.substring(it.indexOf(keyPrefix+".")+keyPrefix.length()+1));
+        Config newConfig = this
+                .filtered(it -> it.startsWith(keyPrefix+"."))
+                .alteringKeys(it -> it.substring(it.indexOf(keyPrefix+".")+keyPrefix.length()+1));
+        return new MapBasedConfig(builder, newConfig.asMap(), definitions, key.isEmpty() ? keyPrefix : key + "." + keyPrefix);
     }
 
 
@@ -80,6 +92,10 @@ public class MapBasedConfig extends AbstractConfig {
         return values.get(key) instanceof List;
     }
 
+    @Override
+    public String key() {
+        return key;
+    }
 
     @Override
     public Iterable<String> keys() {

--- a/src/test/java/imconfig/test/TestConfigurationFactory.java
+++ b/src/test/java/imconfig/test/TestConfigurationFactory.java
@@ -31,6 +31,7 @@ public class TestConfigurationFactory {
     private static final String KEY_ENV = "test.env.key";
     private static final String VAL_ENV = "Test Environment Value";
 
+    private static final String KEY_PROPERTIES = "properties.test.key";
     private static final String KEY_STRING = "properties.test.key.string";
     private static final String KEY_STRINGS = "properties.test.key.strings";
     private static final String KEY_BOOL = "properties.test.key.bool";
@@ -441,6 +442,8 @@ public class TestConfigurationFactory {
             );
 
         assertNullProperties(conf);
+        Assertions.assertThat(conf.inner(KEY_ENV).key()).isEqualTo(KEY_ENV);
+        Assertions.assertThat(conf.inner(KEY_PROPERTIES).inner("string").key()).isEqualTo(KEY_STRING);
     }
 
 


### PR DESCRIPTION
When a new configuration is created from a key prefix using the `inner` method, that prefix is stored in the new configuration, so we know where we are.